### PR TITLE
DM-10463 Make search and display SDSS and WISE time series data from Object search result

### DIFF
--- a/src/suit/html/suit.html
+++ b/src/suit/html/suit.html
@@ -7,7 +7,14 @@
     <title>LSST PDAC</title>
 
     <script>
-        window.firefly = {app: {template: 'FireflyViewer'}};     // set to app mode, instead of api.
+        window.firefly = {
+                            app: {
+                               template: 'FireflyViewer',     // set to app mode, instead of api.
+                               options: {
+                                 charts: {chartEngine: 'plotly'}
+                               }
+                            }
+                         };
     </script>
     <script  type="text/javascript" src="firefly_loader.js"></script>
 </head>

--- a/src/suit/html/ts.html
+++ b/src/suit/html/ts.html
@@ -7,7 +7,14 @@
     <title>LSST PDAC</title>
 
     <script>
-        window.firefly = {app: {template: 'LightCurveViewer'}};     // set to use the light curve template
+        window.firefly = {
+                            app: {
+                               template: 'LightCurveViewer',     // set to use the light curve template
+                                options: {
+                                    charts: {chartEngine: 'plotly'}
+                                }
+                            }
+                         };
     </script>
     <script  type="text/javascript" src="firefly_loader.js"></script>
 </head>

--- a/src/suit/js/actions.jsx
+++ b/src/suit/js/actions.jsx
@@ -34,15 +34,19 @@ function launchTimeSeries({tbl_id, highlightedRow}) {
     } else {
         const row = getTblRowAsObj(getTblById(tbl_id), highlightedRow) || {};
         const {mission, tableName, database, objectIdColumn} = get(tableModel, 'tableMeta') || {};
-        const objectId = objectIdColumn ? get(row, objectIdColumn, undefined) : undefined; // || row.id;  this yield too many empty table.
-        const META_INFO = {[LC.META_MISSION]: mission};
-        req = makeTblRequest('LSSTLightCurveQuery', objectId, {objectId, table_name: tableName, database}, {tbl_id: LC.RAW_TABLE, META_INFO});
+        const objectId = objectIdColumn ? get(row, objectIdColumn, undefined) : undefined;
 
-        if (mission.toLowerCase().includes('wise')) {
-           req = req && addExistingConstraints(tableModel, req);
+        if (!isNil(objectId)) {
+            const META_INFO = {[LC.META_MISSION]: mission};
+
+            req = makeTblRequest('LSSTLightCurveQuery', objectId, {objectId, table_name: tableName, database}, {tbl_id: LC.RAW_TABLE, META_INFO});
+
+            if (mission.toLowerCase().includes('wise')) {
+                req = req && addExistingConstraints(tableModel, req);
+            }
+
+            req && getViewer(undefined, 'timeseries').showTable(req);
         }
-
-        req && getViewer(undefined, 'timeseries').showTable(req);
     }
 }
 
@@ -89,9 +93,9 @@ function checkForTimeSeriesData({tbl_id, highlightedRow}) {
                  return bShow;
         };
 
-        const show = showView()&&(!!objectId);
+        const show = showView();
 
-        return {show, enable:show&&showEnable(),  title: `View Time Series: ${objectId}${noteForSDSS}`};
+        return {show, enable:(!!objectId)&&show&&showEnable(),  title: `View Time Series: ${objectId}${noteForSDSS}`};
     }
 }
 

--- a/src/suit/js/actions.jsx
+++ b/src/suit/js/actions.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import {get, set, cloneDeep} from 'lodash';
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {get, set, has, cloneDeep, omitBy, isNil} from 'lodash';
 import {ActiveTableButton} from 'firefly/tables/ui/ActiveTableButton.jsx';
 import {getTblById, getTblRowAsObj, makeTblRequest} from 'firefly/tables/TableUtil.js';
 import {getViewer} from 'firefly/api/ApiViewer.js';
 import {LC} from 'firefly/templates/lightcurve/LcManager.js';
+import {FORCEDSOURCE, SOURCE, LSSTCatalogTableType} from 'firefly/visualize/ui/LSSTCatalogSelectViewPanel.jsx';
 
 
 export function timeSeriesButton() {
@@ -14,6 +16,7 @@ export function timeSeriesButton() {
                 type = 'highlight'
                 onChange = {checkForTimeSeriesData}
                 onClick = {launchTimeSeries}
+                style= {{maxWidth: 220}}
             />
         </div>
     );
@@ -21,28 +24,69 @@ export function timeSeriesButton() {
 
 function launchTimeSeries({tbl_id, highlightedRow}) {
     const tableModel = getTblById(tbl_id) || {};
+    let req;
+
     if (isTimeSeriesTable(tableModel)) {
-        const req = cloneDeep(get(tableModel, 'request'));
+        req = cloneDeep(get(tableModel, 'request'));
         req.tbl_id = LC.RAW_TABLE;
         set(req, 'META_INFO.tbl_id', LC.RAW_TABLE);
         req && getViewer(undefined, 'timeseries').showTable(req);
     } else {
         const row = getTblRowAsObj(getTblById(tbl_id), highlightedRow) || {};
-        const objectId = row.objectId; // || row.id;  this yield too many empty table.
-        const META_INFO = {[LC.META_MISSION]: 'lsst_sdss'};
-        const req = makeTblRequest('LSSTLightCurveQuery', objectId, {objectId}, {tbl_id: LC.RAW_TABLE, META_INFO});
-        getViewer(undefined, 'timeseries').showTable(req);
+        const {mission, tableName, database, objectIdColumn} = get(tableModel, 'tableMeta') || {};
+        const objectId = objectIdColumn ? get(row, objectIdColumn, undefined) : undefined; // || row.id;  this yield too many empty table.
+        const META_INFO = {[LC.META_MISSION]: mission};
+        req = makeTblRequest('LSSTLightCurveQuery', objectId, {objectId, table_name: tableName, database}, {tbl_id: LC.RAW_TABLE, META_INFO});
+
+        if (mission.toLowerCase().includes('wise')) {
+           req = req && addExistingConstraints(tableModel, req);
+        }
+
+        req && getViewer(undefined, 'timeseries').showTable(req);
     }
+}
+
+function addExistingConstraints(tableModel, req) {
+    const {SearchMethod, UserTargetWorldPt, constraints, radius, size, ratio, polygon, posang,  sizeUnit} = get(tableModel, ['request']);
+
+    return omitBy(Object.assign(req, {SearchMethod, UserTargetWorldPt, constraints, radius, size, ratio, polygon, posang,  sizeUnit}), isNil);
 }
 
 function checkForTimeSeriesData({tbl_id, highlightedRow}) {
     const tableModel = getTblById(tbl_id) || {};
+
     if (isTimeSeriesTable(tableModel)) {
         return {show: true, title: 'View table as Time Series'};
     } else {
         const row = getTblRowAsObj(getTblById(tbl_id), highlightedRow) || {};
-        const objectId = row.objectId; // || row.id;  this yield too many empty table.
-        return {show: Boolean(objectId), title: `View Time Series: ${objectId}`};
+        const {mission, tableType, filterIdColumn, objectIdColumn} = get(tableModel, 'tableMeta', {});
+        const objectId = objectIdColumn ? get(row, objectIdColumn, '') : '';
+        const hasForcedSource = (tt) => {
+                var ttype = !tt ? -1 :
+                            [SOURCE, FORCEDSOURCE]
+                                .findIndex((v) => LSSTCatalogTableType[v].toLowerCase() === tt.toLowerCase());
+
+                return ttype !== -1;
+        };
+
+        const showView = () => {
+                if (!mission || !hasForcedSource(tableType)) {
+                   return false;
+                }
+                return true;
+        };
+
+        const showEnable = () => {   // disable the button for sdss, object, and not i band
+                 if (mission.toLowerCase().includes('wise')) return true;
+                 const sdssBand = {u: '0', g: '1', r:'2', i: '3', z: '4'};
+                 const filterId = filterIdColumn ? get(row, filterIdColumn) : sdssBand.i;
+
+                 return filterId && filterId === sdssBand.i ? true : false;
+        };
+
+        const show = showView()&&(!!objectId);
+
+        return {show, enable:show&&showEnable(),  title: `View Time Series: ${objectId}`};
     }
 }
 

--- a/src/suit/js/actions.jsx
+++ b/src/suit/js/actions.jsx
@@ -61,6 +61,8 @@ function checkForTimeSeriesData({tbl_id, highlightedRow}) {
         const row = getTblRowAsObj(getTblById(tbl_id), highlightedRow) || {};
         const {mission, tableType, filterIdColumn, objectIdColumn} = get(tableModel, 'tableMeta', {});
         const objectId = objectIdColumn ? get(row, objectIdColumn, '') : '';
+        let   noteForSDSS = '';
+
         const hasForcedSource = (tt) => {
                 var ttype = !tt ? -1 :
                             [SOURCE, FORCEDSOURCE]
@@ -79,14 +81,17 @@ function checkForTimeSeriesData({tbl_id, highlightedRow}) {
         const showEnable = () => {   // disable the button for sdss, object, and not i band
                  if (mission.toLowerCase().includes('wise')) return true;
                  const sdssBand = {u: '0', g: '1', r:'2', i: '3', z: '4'};
-                 const filterId = filterIdColumn ? get(row, filterIdColumn) : sdssBand.i;
+                 const bShow = filterIdColumn ? get(row, filterIdColumn) === sdssBand.i : true;
 
-                 return filterId && filterId === sdssBand.i ? true : false;
+                 if (!bShow) {
+                     noteForSDSS = ', forced photometry is limited to i-band objects only.';
+                 }
+                 return bShow;
         };
 
         const show = showView()&&(!!objectId);
 
-        return {show, enable:show&&showEnable(),  title: `View Time Series: ${objectId}`};
+        return {show, enable:show&&showEnable(),  title: `View Time Series: ${objectId}${noteForSDSS}`};
     }
 }
 


### PR DESCRIPTION
#This development recompute the display of 'view time series' button based on LSST SDSS and WISE data search results, and you may get time series view by clicking that button from either object search or forced source search result.  
- catalog search: 
   . for WISE source table or forced source table search: 'view time series'  button is enabled with the object id (column name: 'cntr' or 'cntr_mf') of the selected row. 
     Note: the time series search inherits the geometric constraints from the object search for WISE for efficient search. 
   . for WISE single exposure source table search : no 'view time series' button is shown. (search of this type of catalog is not available yet) 
   . for SDSS source table search: 'view time series' button with the object id (column name: 'id') is enabled if the row of i-band is selected, or disabled if the row of other bands is selected. 
  . for SDSS forced source table search result: 'view time series' button with the object id (column name: 'objectId') is enabled. 
- image (metadata table) search: 
   no 'view time series' button is shown.

Test:
pull this branch and the branch DM-10463-TSFromObjectSearch from Firefly. 
build both locally. 
run as localhost:8080/suit

for SDSS: 
   - select 'SSDS stripe 82' -> catalogs -> Object 
      target: 9.6 -1.1 and cone, 10 arcsec -> search
      on tri-view, you may select to see columns 'id' and 'coadd_filter_id' from the result table, and the 'view time series' button becomes active if the highlighted row with coadd_filter_id = 3. 
      click on the active button to get time series view from the selected object. 
   - select 'SDSS stripe 82' -> catalogs -> 'Forced photometry based on i-band coadds'
      target: 9.6 -1.1 and cone, 10 arcsec -> search
      on tri-view, click on the 'view time series' button to get time series view from the selected object. 

for WISE: 
  - select 'wise 00' -> catalogs -> 'ALLWISE Source Catalog' (or 
'ALLWISE Multiepoch photometry table'). 
     target: 9.6 -1.1 and cone, 100 arcsec -> search
     click on 'view time series' button to get times series view from the selected object. 
    
