### PR TITLE
IRSA-1709: Catalog search intermittently fail to load results

### DIFF
--- a/src/suit/html/suit.html
+++ b/src/suit/html/suit.html
@@ -8,13 +8,10 @@
 
     <script>
         window.firefly = {
-                            app: {
-                               template: 'FireflyViewer',     // set to app mode, instead of api.
-                               options: {
-                                   charts: {chartEngine: 'plotly', multitrace: true}
-                               }
-                            }
-                         };
+            app: {
+               template: 'FireflyViewer',     // set to app mode, instead of api.
+            }
+        };
     </script>
     <script  type="text/javascript" src="firefly_loader.js"></script>
 </head>

--- a/src/suit/html/ts.html
+++ b/src/suit/html/ts.html
@@ -8,13 +8,14 @@
 
     <script>
         window.firefly = {
-                            app: {
-                               template: 'LightCurveViewer',     // set to use the light curve template
-                                options: {
-                                    charts: {chartEngine: 'plotly'}
-                                }
-                            }
-                         };
+            app: {
+               template: 'LightCurveViewer',     // set to use the light curve template
+                menu: [
+                    {label:'Upload', action:'LCUpload'},
+                    {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
+                ],
+            }
+        };
     </script>
     <script  type="text/javascript" src="firefly_loader.js"></script>
 </head>

--- a/src/suit/js/SUIT.js
+++ b/src/suit/js/SUIT.js
@@ -5,49 +5,37 @@
 
 import {get} from 'lodash';
 
-import {firefly, Templates} from 'firefly/Firefly.js';
+import {firefly} from 'firefly/Firefly.js';
 import {timeSeriesButton} from './actions.jsx';
-// import {HELP_LOAD} from 'firefly/core/AppDataCntlr.js';
+import {mergeObjectOnly} from 'firefly/util/WebUtil.js';
 
 
 /**
  * This entry point is customized for LSST suit.  Refer to FFEntryPoint.js for information on 
  * what could be used in defaults.
  */
-const defaults = {
-    div: 'app',
+var props = {
     showUserInfo: true,
-    appTitle: '',
     appIcon: 'images/lsst_logo.png',
-    template: 'FireflyViewer',
+    showViewsSwitch: true,
+    rightButtons: [timeSeriesButton],
     menu: [
         {label: 'LSST Data', action: 'LsstCatalogDropDown'},
         {label: 'External Images', action: 'ImageSelectDropDownCmd'},
         {label: 'External Catalogs', action: 'IrsaCatalogDropDown'},
         {label: 'Add Chart', action: 'ChartSelectDropDownCmd'}
     ], 
-    options: {
-        MenuItemKeys: {maskOverlay: true},
-        imageTabs: ['fileUpload', 'url', '2mass', 'wise', 'sdss', 'msx', 'dss', 'iras'],
-        irsaCatalogFilter: 'lsstFilter',
-        catalogSpacialOp: 'polygonWhenPlotExist'
-    },
-    rightButtons: [timeSeriesButton]
 };
 
-const app = get(window, 'firefly.app', {});
-const options = Object.assign({}, defaults.options, app.options);
+var options = {
+    MenuItemKeys: {maskOverlay: true},
+    imageTabs: ['fileUpload', 'url', '2mass', 'wise', 'sdss', 'msx', 'dss', 'iras'],
+    irsaCatalogFilter: 'lsstFilter',
+    catalogSpacialOp: 'polygonWhenPlotExist',
+    charts: {chartEngine: 'plotly', multitrace: true}
+};
 
-var viewer, props;
-if (app.template) {
-    if (app.template === 'LightCurveViewer') {
-        defaults.menu = [
-            {label:'Upload', action:'LCUpload'},
-            {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
-        ];
-    }
-    props = Object.assign({}, defaults, app);
-    viewer = Templates[props.template];
-}
 
-firefly.bootstrap(options, viewer, props);
+props = mergeObjectOnly(props, get(window, 'firefly.app', {}));
+options = mergeObjectOnly(options, get(window, 'firefly.options', {}));
+firefly.bootstrap(props, options);


### PR DESCRIPTION
- remove old GWT code
- refactor Table code to use a generic 'Send to background' panel
- clean up app props
  - introduce FireflyProps at top level
  - startup-options hangs under that. i.e.  props.options
  - viewer is no longer needed.  resolved from template.
  - defaults are defined in Firefly.js
  - bootstrap takes only one 'props' parameter.
  - deep merge