### PR TITLE
Dm 18396 unify suit firefly

### DIFF
--- a/config/k8s/suit-int.yaml
+++ b/config/k8s/suit-int.yaml
@@ -95,7 +95,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
-    nginx.ingress.kubernetes.io/rewrite-target: /app
+    nginx.ingress.kubernetes.io/rewrite-target: /suit
     nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
     nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2
     nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/app

--- a/config/k8s/suit-int.yaml
+++ b/config/k8s/suit-int.yaml
@@ -86,7 +86,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: suit
+  name: portal-app
   namespace: portal-int
   annotations:
     kubernetes.io/ingress.class: "nginx"

--- a/config/k8s/suit-int.yaml
+++ b/config/k8s/suit-int.yaml
@@ -95,6 +95,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "24k"
     nginx.ingress.kubernetes.io/rewrite-target: /suit
     nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
     nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2

--- a/config/k8s/suit-int.yaml
+++ b/config/k8s/suit-int.yaml
@@ -95,15 +95,15 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
-    nginx.ingress.kubernetes.io/rewrite-target: /suit
-    nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/(.+)$
-    nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/$2
-    nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/suit
+    nginx.ingress.kubernetes.io/rewrite-target: /app
+    nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
+    nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2
+    nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/app
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Original-URI $request_uri;
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-Port 443;
-      proxy_set_header X-Forwarded-Path /portal/suit;
+      proxy_set_header X-Forwarded-Path /portal/app;
       error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
 spec:
   tls:
@@ -114,7 +114,7 @@ spec:
   - host: lsst-lsp-int.ncsa.illinois.edu
     http:
       paths:
-      - path: "/portal/suit"
+      - path: "/portal/app"
         backend:
           serviceName: suit
           servicePort: 8080

--- a/config/k8s/suit-stable.yaml
+++ b/config/k8s/suit-stable.yaml
@@ -92,7 +92,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
-    nginx.ingress.kubernetes.io/rewrite-target: /app
+    nginx.ingress.kubernetes.io/rewrite-target: /suit
     nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
     nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2
     nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/app

--- a/config/k8s/suit-stable.yaml
+++ b/config/k8s/suit-stable.yaml
@@ -92,6 +92,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "24k"
     nginx.ingress.kubernetes.io/rewrite-target: /suit
     nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
     nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2

--- a/config/k8s/suit-stable.yaml
+++ b/config/k8s/suit-stable.yaml
@@ -92,15 +92,15 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/proxy-body-size: "0m"
-    nginx.ingress.kubernetes.io/rewrite-target: /suit
-    nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/(.+)$
-    nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/$2
-    nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/suit
+    nginx.ingress.kubernetes.io/rewrite-target: /app
+    nginx.ingress.kubernetes.io/proxy-redirect-from: ~^(http[s]?://[^/]+)/suit/(.+)$
+    nginx.ingress.kubernetes.io/proxy-redirect-to: $1/portal/app/$2
+    nginx.ingress.kubernetes.io/proxy-cookie-path: /suit /portal/app
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Original-URI $request_uri;
       proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-Port 443;
-      proxy_set_header X-Forwarded-Path /portal/suit;
+      proxy_set_header X-Forwarded-Path /portal/app;
       error_page 403 = "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
 spec:
   tls:
@@ -111,7 +111,7 @@ spec:
   - host: lsst-lsp-stable.ncsa.illinois.edu
     http:
       paths:
-      - path: "/portal/suit"
+      - path: "/portal/app"
         backend:
           serviceName: suit
           servicePort: 8080

--- a/src/suit/html/slate.html
+++ b/src/suit/html/slate.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>LSST Portal</title>
+
+    <script>
+        window.firefly = {
+            app: {
+                template: 'FireflySlate',
+                menu: [
+                    {label:'Images', action:'ImageSelectDropDownSlateCmd'},
+                    {label:'Catalogs', action:'IrsaCatalogDropDown'},
+                    {label:'Charts', action:'ChartSelectDropDownCmd'},
+                    {label:'Upload', action: 'FileUploadDropDownCmd'},
+                ],
+                showBgMonitor: false
+            },
+            options : {
+                MenuItemKeys: {maskOverlay:true},
+                catalogSpacialOp: 'polygonWhenPlotExist',
+                disableDefaultDropDown: true,
+                charts: {defaultDeletable: true},
+                readoutDefaultPref: {imageMouseReadout2:'zeroIP'}
+            }
+        };
+    </script>
+    <script  type="text/javascript" src="firefly_loader.js"></script>
+</head>
+
+<body style="margin: 0; background-color: rgb(200,200,200)">
+<!-- attached location for firefly app -->
+<div id='app'/>
+
+
+
+
+</body>
+
+</html>
+
+

--- a/src/suit/html/suit.html
+++ b/src/suit/html/suit.html
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <title>LSST PDAC</title>
+    <title>LSST Portal</title>
 
     <script>
         window.firefly = {

--- a/src/suit/html/ts.html
+++ b/src/suit/html/ts.html
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <title>LSST PDAC</title>
+    <title>LSST Portal</title>
 
     <script>
         window.firefly = {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-18396
test: https://lsst-lsp-int.ncsa.illinois.edu/portal/app/

- add slate to suit
- update ingress to expose endpoints defined in DM-17973
  - /portal/app/
  - /portal/app/ts.html
  - /portal/app/slate.html

`suit` is updated; built on suit's `master` and firefly's `lsst-dev`.
Both endpoints `/portal/suit/` and `/portal/app/` are mapped to the same pods.

@stargaser please verify that references to `/firefly/` in notebook and awf_display can be replaced with `/portal/app/`.

