### PR TITLE
DM-16667 Use TAP provided by DAX team when available

### DIFF
--- a/src/suit/js/SUIT.js
+++ b/src/suit/js/SUIT.js
@@ -21,10 +21,12 @@ var props = {
     showViewsSwitch: true,
     rightButtons: [timeSeriesButton],
     menu: [
-        {label: 'LSST Data', action: 'LsstCatalogDropDown'},
+        {label: 'LSST TAP', action: 'TAPSearch'},
+        {label: 'Legacy PDAC', action: 'LsstCatalogDropDown'},
         {label: 'External Images', action: 'ImageSelectDropDownCmd'},
         {label: 'External Catalogs', action: 'IrsaCatalogDropDown'},
-        {label: 'Add Chart', action: 'ChartSelectDropDownCmd'}
+        {label: 'Add Chart', action: 'ChartSelectDropDownCmd'},
+        {label: 'Upload', action: 'FileUploadDropDownCmd'}
     ],
 };
 
@@ -36,7 +38,25 @@ var options = {
     // hips : {useForCoverage: false, useForImageSearch: true,
     //     hipsSources: 'all',
     //     defHipsSources: {source: 'irsa', label: 'Featured'},
-    //     mergedListPriority: 'irsa'}
+    //     mergedListPriority: 'irsa'},
+    tap : {
+        services: [
+            { label: 'LSST lsp-stable https://lsst-lsp-stable.ncsa.illinois.edu/api/tap',
+                value: 'https://lsst-lsp-stable.ncsa.illinois.edu/api/tap' },
+            { label: 'LSST lsp-int https://lsst-lsp-int.ncsa.illinois.edu/api/tap',
+                value: 'https://lsst-lsp-int.ncsa.illinois.edu/api/tap' },
+            { label: 'CADC https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap',
+                value: 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap' },
+            { label: 'GAIA https://gea.esac.esa.int/tap-server/tap',
+                value: 'https://gea.esac.esa.int/tap-server/tap' },
+            { label: 'IRSA https://irsa.ipac.caltech.edu/TAP',
+                value: 'https://irsa.ipac.caltech.edu/TAP' },
+            { label: 'MAST https://vao.stsci.edu/CAOMTAP/TapService.aspx',
+                value: 'https://vao.stsci.edu/CAOMTAP/TapService.aspx' },
+            { label: 'NED https://ned.ipac.caltech.edu/tap',
+                value: 'https://ned.ipac.caltech.edu/tap/' },
+        ]
+    }
 };
 
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-16667
A parallel PR is created in https://github.com/Caltech-IPAC/firefly. 

Please , build suit locally and test with VPN.

Steps to test (can be also used for demo):

**LSST Spatial queries**

Spatial query using sdss_stripe82_01.RunDeepSource:

Notice coord_ra, coord_dec are discovered as ra and dec columns using UCDs. 

Using pos: 350, 0.1, radius 100’’. Click “Populate ADQL”.

`SELECT TOP 10000 * FROM sdss_stripe82_01.RunDeepSource WHERE CONTAINS(POINT('ICRS', coord_ra, coord_decl),CIRCLE('ICRS', 350, 0.1, 0.02777777777777778))=1`

Remove `TOP 10000`, otherwise you’ll get “Failure while merging result” error.

**LSST Temporal queries**

MJD format is common when recording observation time, IOS format is common when recording processing time.

1. CCD exposures between 2001-06-15 and 2001-06-16. Choose taiMjd column; in “FROM” field type "2001-06” then use Calendar, choose the date. Same for “TO” field. Use "Populate ADQL”. The date is automatically converted to MJD format.   

`SELECT TOP 10000 * FROM sdss_stripe82_01.Science_Ccd_Exposure WHERE (taiMjd >= 52075 AND taiMjd <= 52076)`

Do the same using obsStart date. The query will be

`SELECT TOP 10000 * FROM sdss_stripe82_01.Science_Ccd_Exposure WHERE (obsStart >= '2001-06-01T00:00:00Z' AND obsStart <= '2001-06-16T00:00:00Z’)`

Notice that it now uses ISO format. Temporal queries with ISO time constraints should work for the timestamp fields - xtype=timestamp - ISO format will be automatically converted to the internal format by the service provider. Otherwise string comparison is used, users should be aware of this.

2. Example of timestamp fields can be found in CADC caom2.Observation table. Use column constraints table to find the columns with xtype=timestamp.

   Find observations modified today: FROM: 2019-03-14 

3. ADQL schema browser: clear the query, expand schema nodes, click on table nodes.

Known DAX issues, affecting LSST TAP search: DM-17295, DM-18447, DM-18451.
Related errors:
- 'SQLException:Query processing error: QI=?: Failed to instantiate query: AnalysisError:Spatial restrictor w/o partitioned table' (DM-17295, test case: spatial restriction on DeepCoadd)
- 'SQLException:Unable to return query results: Failure while merging result' (DM-18447, test case: TOP on sdss_stripe82_01.RunDeepSource)
- 'SQLException:Query processing error: QI=?: Failed to instantiate query: NoSuchTable:Table 'gaiadr2.gaia_source' does not exist.' (DM-18451, test case: first schema, first table, any query)

Data issue found:
- sdss_stripe82_01.RunDeepSource has variance for 'ra' has wrong ucd: 'stat.variance;pos.eq' instead of 'stat.variance;pos.eq.ra'.


 