### PR TITLE
DM-20048: enable redis to run with password protection

### DIFF
--- a/config/k8s/suit-int.yaml
+++ b/config/k8s/suit-int.yaml
@@ -45,6 +45,8 @@ spec:
             secretKeyRef:
               name: suit-secret
               key: ADMIN_PASSWORD
+        - name: REDIS_PASSWORD
+          value: "$(ADMIN_PASSWORD)"
         - name: FIREFLY_OPTS
           value: "-Dvisualize.fits.search.path=/datasets"
         - name: FIREFLY_SHARED_WORK_DIR
@@ -141,22 +143,30 @@ spec:
       nodeSelector:
         environment: portal-int
       tolerations:
-        - key: "dedicated"
-          operator: "Equal"
-          value: "portal"
-          effect: "NoSchedule"
+      - key: "dedicated"
+        operator: "Equal"
+        value: "portal"
+        effect: "NoSchedule"
       securityContext:
         runAsUser: 101
         fsGroup: 101
       containers:
-        - name: redis-srv
-          image: redis:5
-          imagePullPolicy: Always
-          resources:
-            limits:
-              memory: "20Mi"
-          ports:
-            - containerPort: 6379
+      - name: redis-srv
+        image: redis:5
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: suit-secret
+              key: ADMIN_PASSWORD
+        command: ["redis-server"]
+        args: ["--requirepass", "$(REDIS_PASSWORD)"]
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "20Mi"
+        ports:
+          - containerPort: 6379
 ---
 
 apiVersion: v1

--- a/config/k8s/suit-stable.yaml
+++ b/config/k8s/suit-stable.yaml
@@ -45,6 +45,8 @@ spec:
             secretKeyRef:
               name: suit-secret
               key: ADMIN_PASSWORD
+        - name: REDIS_PASSWORD
+          value: "$(ADMIN_PASSWORD)"
         - name: FIREFLY_OPTS
           value: "-Dvisualize.fits.search.path=/datasets"
         - name: FIREFLY_SHARED_WORK_DIR
@@ -141,22 +143,30 @@ spec:
       nodeSelector:
         environment: portal-stable
       tolerations:
-        - key: "dedicated"
-          operator: "Equal"
-          value: "portal"
-          effect: "NoSchedule"
+      - key: "dedicated"
+        operator: "Equal"
+        value: "portal"
+        effect: "NoSchedule"
       securityContext:
         runAsUser: 101
         fsGroup: 101
       containers:
-        - name: redis-srv
-          image: redis:5
-          imagePullPolicy: Always
-          resources:
-            limits:
-              memory: "20Mi"
-          ports:
-            - containerPort: 6379
+      - name: redis-srv
+        image: redis:5
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: suit-secret
+              key: ADMIN_PASSWORD
+        command: ["redis-server"]
+        args: ["--requirepass", "$(REDIS_PASSWORD)"]
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "20Mi"
+        ports:
+          - containerPort: 6379
 ---
 
 apiVersion: v1


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-20048
Do not allow unauthenticated connections to redis running in LSST kubernetes instances.

Additional changes here: https://github.com/Caltech-IPAC/firefly/pull/843

Not sure how to test this.  The changes are in LSST now.  Using the status page, you will see that a password is used and cache is replicating.

test: https://lsst-lsp-int.ncsa.illinois.edu/portal/app/admin/status
