### PR TITLE
Tickets/DM-22455: prepare for SUIT (Portal) release 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,25 @@
+##########
+Change log
+##########
+
+1.1.0 (2019-12-03)
+==================
+
+- Activated Firefly-release-pinning mechanism (NB: only on release branches of ``suit``).  Improved messaging when the LSP-local TAP service cannot be reliably inferred.
+  [`DM-22455 <https://jira.lsst.org/browse/DM-22455>`_]
+
+- Started automatically computing the TAP service URL from the base URL of the LSP instance, and ensured that this works correctly when Firefly is invoked within the Notebook Aspect (as a JupyterLab extension).
+  [`DM-21846 <https://jira.lsst.org/browse/DM-21846>`_]
+  [`DM-22331 <https://jira.lsst.org/browse/DM-22331>`_]
+
+- **Uses Firefly release-2019.3.2.**  See the `Firefly release notes <https://github.com/Caltech-IPAC/firefly/blob/dev/docs/release-notes.md>`.  Key LSST-relevant features:
+
+  - Build scripts support release-pinning in application packages.
+    [`DM-20931 <https://jira.lsst.org/browse/DM-20931>`_]
+
+  - TAP logic conforms to LSST requirements for including Authorization: headers when TAP result URLs are redirected.
+    [`DM-21921 <https://jira.lsst.org/browse/DM-21921>`_]
+
+- Known bugs:
+
+  - A change in table handling in Firefly 2019.3.x inadvertently broke the LSST detection footprint visualization capability.  Will be fixed in the next major Firefly release.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # SUIT 
 
 
-#### Description
-SUIT (Science User Interface and Tools) repository contains applications build on the Firefly Toolkit.  It is meant to be used with [Firefly] (https://github.com/Caltech-IPAC/firefly)
+## Description
+The SUIT (Science User Interface and Tools) repository contains applications built on the Firefly Toolkit.
+It is meant to be used with [Firefly](https://github.com/Caltech-IPAC/firefly).
+
+The principal current application is "suit", otherwise known as the Portal Aspect application, which
+contains both the Portal search screens and visualization capabilities, and the "slate" endpoint that
+is used for Python-based image and table visualizations.
 
 
-#### Build Instuctions
+## Build Instuctions
  
  - Install [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)   
    
@@ -33,6 +38,46 @@ SUIT (Science User Interface and Tools) repository contains applications build o
         cd suit
         gradle :suit:onlinehelp :suit:warAll
    
- 
+### Release configuration management
 
+The SUIT build process provides for the ability to include in a release of the SUIT source code an explicit statement of the Firefly release (Github tag) against which it is to be built.
 
+The philosophy of use of this feature is that `suit:master` will **not** use that feature, so that a standard build of the package from the tip of `master` will by default be performed against the tip of the Firefly default branch (which is `dev` for Firefly, not `master`).
+However, in a release branch of `suit`, the feature will be used to constrain the build to a released version of Firefly, by setting that tag in a `config/firefly_build.tag` file in the repo.
+**Edits to that file should always be performed in separate commits** and not commingled with any code, documentation, or release note changes, so that these commits can rigorously be excluded from merging to `suit:master`.
+
+Test builds of `suit` against specific non-release versions of Firefly can be made by creating a `suit` branch in which the `config/firefly_build.tag` file is set appropriately.
+
+#### Details
+
+There are 2 ways to specify the tag:
+
+1. set it in `firefly.tag.name` property
+2. set it in a file referenced by a `firefly.tag.file` property
+
+**Examples:**
+
+`gradle -Pfirefly.tag.name=abc123 suit:checkoutFirefly`
+
+The build will rightfully complain that 'abc123' does not match any tag or branch.
+
+The default value of `firefly.tag.file` is set to `config/firefly_build.tag`.
+Let's try using that file.
+
+`gradle suit:checkoutFirefly`
+
+This produces a "tag not found" error, because there's nothing in the file.
+Now try placing a tag into the file and run it again.
+
+```
+echo 'master' > config/firefly_build.tag
+gradle suit:checkoutFirefly
+git -C ../firefly branch
+```
+
+This sets the Firefly version to use to "master", easily verified by running `git branch` in the `firefly` directory after this.
+
+As demonstrated, there are many ways to use this.
+It can be passed in at the command line.
+It can be specified in a file.
+You can also have different tags or different files for each of the environments if needed.

--- a/config/app.config
+++ b/config/app.config
@@ -2,7 +2,7 @@
 // adjustable application runtime properties
 //---------------------------------------------
 BuildMajor = 1
-BuildMinor = 0
+BuildMinor = 1
 BuildRev = 0
 BuildNumber = 0
 BuildType = "Final"
@@ -65,6 +65,7 @@ __$workspace.propfind.infinity = false
 
 // ehcache.xml env sensitive properties
 // ehcahe replication port; suggest 4077-developer, 5077-dev, 6077-I&T, 7077-Prod, 8077-Public
+// peerDiscovery can be "PubSub" for the redis-based discovery mechanism, or "MultiCast" for the original
 ehcache.multicast.port = "7077"
 ehcache.peerDiscovery = "PubSub"
 redis.host = "redis-srv"

--- a/src/suit/build.gradle
+++ b/src/suit/build.gradle
@@ -19,26 +19,19 @@ onlinehelp {
 }
 
 ext.appConfig = {
-  BuildMajor  = "1"
-  BuildMinor  = "0"
-  BuildRev    = "1"
-
-  ehcache.multicast.port = "4077"
-
   firefly.tag.file = "../../config/firefly_build.tag"
 
   environments {
     dev {
-      ehcache.multicast.port = "5077"
+
     }
 
     test {
-      ehcache.multicast.port = "6077"
+
     }
 
     ops {
-      ehcache.multicast.port = "7077"
+
     }
   }
 }
-

--- a/src/suit/js/SUIT.js
+++ b/src/suit/js/SUIT.js
@@ -52,8 +52,12 @@ const TAP_PATH= 'api/tap';
 
 /**
  * @param {String} url
- * @return {{tapUrl:String, confident:Boolean}} the tapUrl is the computed url, confident is true if the url was computed
- * by finding the protal stirng and replacing, otherwise a url might be returned bug confident will be false
+ * @return {{tapUrl:String, confident:Boolean}} the tapUrl is the computed url, where "confident" is true if the url 
+ * was computed by successfully finding the pathname component consistent with the LSP URL conventions -- under
+ * which Firefly might be invoked either as the Portal Aspect application (i.e., under /portal), or as a JupyterLab
+ * extension within the Notebook Aspect (i.e., under /nb) -- and substituting the pathname as appropriate to find
+ * the TAP service (under /api).  Otherwise "confident" will be set to false and a guess at a possible local TAP
+ * service URL will be made.
  */
 function findCorrectLSSTTapService(url) {
     try {
@@ -69,13 +73,13 @@ function findCorrectLSSTTapService(url) {
 
 const {tapUrl,confident}= findCorrectLSSTTapService(window.location.href);
 if (tapUrl) { // if a url is produced with confidence put it at the top otherwise put it at the bottom
-    tapServices=  confident ? [ lsstEntry(tapUrl), ...tapServices ] : [ ...tapServices, lsstEntry(tapUrl) ];
+    tapServices=  confident ? [ lsstEntry(tapUrl), ...tapServices ] : [ ...tapServices, tapEntry('(possible local service)',tapUrl) ];
 }
 
 if (!tapUrl || !confident) {
     setTimeout( () =>
             showInfoPopup(
-                `Could not infer the location of the TAP service for this LSP instance from the window, URL: ${window.location.href}`, 5000));
+                `Could not infer the location of the TAP service for this LSP instance from the window URL: ${window.location.href}`, 5000));
 }
 
 var options = {


### PR DESCRIPTION
Bundle of small changes and documentation associated with preparing for the first formal release of the Portal application / `suit` package, along lines agree with @gcomoretto .

Added a change log file after discussion with @jonathansick .

The changes on this branch all should be merged to master.  A separate "rc-1.1" branch will carry the one-line change to pin the Firefly release to release-2019.3.2 for this Portal release.