### PR TITLE
[DM-30073] Remove .lsst.codes from sso.req.auth.hosts

### DIFF
--- a/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
+++ b/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
@@ -27,7 +27,7 @@ public class LsstSsoAdapter implements SsoAdapter {
     private static Logger.LoggerImpl LOGGER = Logger.getLogger();
     private static String LOGIN_URL         = AppProperties.getProperty("sso.login.url", "/login?rd=/portal/suit/");
     private static String LOGOUT_URL        = AppProperties.getProperty("sso.logout.url", "/logout");
-    private static String REQ_AUTH_HOSTS    = AppProperties.getProperty("sso.req.auth.hosts", ".ncsa.illinois.edu,.lsst.cloud,.lsst.codes");
+    private static String REQ_AUTH_HOSTS    = AppProperties.getProperty("sso.req.auth.hosts", ".ncsa.illinois.edu,.lsst.cloud");
 
     private static final String GROUPS_HEADER = "X-Auth-Request-Groups";
     private static final String EMAIL_HEADER = "X-Auth-Request-Email";


### PR DESCRIPTION
This caused SUIT to include Gafaelfawr auth tokens in requests for
async results from the async-results.lsst.codes Google bucket,
which in turn confused Google and caused it to reject the request.
(The bucket does not require authentication.)

The intent of including .lsst.codes was to get SUIT to send auth
when making in-cluster requests for clusters in the .lsst.codes
domain, but this is primarily for TAP and we don't use SUIT with
TAP in clusters ending in .lsst.codes except for the minikube and
red-five test clusters.  Remove .lsst.codes again to fix the async
result retrieval, and we'll live with it not authenticating to TAP
in those clusters.  The important inclusion is .lsst.cloud, which
forces SUIT to send credentials for in-cluster requests in the IDF.