### PR TITLE
[DM-31056] Stop attempting to get user's full name

### DIFF
--- a/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
+++ b/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
@@ -31,14 +31,12 @@ public class LsstSsoAdapter implements SsoAdapter {
 
     private static final String GROUPS_HEADER = "X-Auth-Request-Groups";
     private static final String EMAIL_HEADER = "X-Auth-Request-Email";
-    private static final String NAME_HEADER = "X-Auth-Request-Name";
     private static final String TOKEN_HEADER = "X-Auth-Request-Token";
     private static final String USERNAME_HEADER = "X-Auth-Request-Username";
 
     // the keywords are listed in https://confluence.lsstcorp.org/display/LAAIM/Web+SSO
     private static final String USER_NAME = "sub"; // ex.value "http://cilogon.org/serverT/users/123456'
     private static final String UID = "uid"; // ex.value "username"
-    private static final String NAME = "name";
     private static final String EMAIL = "email";
     private static final String EXPIRES = "exp";
     private static final String ID_TOKEN = "X-Auth-Request-Token";
@@ -59,7 +57,6 @@ public class LsstSsoAdapter implements SsoAdapter {
                     token = new Token(String.valueOf(claims.get(USER_NAME)));
                     token.setExpiresOn(StringUtils.getInt(claims.get(EXPIRES), 0));
                     token.set(EMAIL, String.valueOf(claims.get(EMAIL)));
-                    token.set(NAME, String.valueOf(claims.get(NAME)));
                     token.set(UID, String.valueOf(claims.get(UID)));
                     token.set(ID_TOKEN, id_token);
 
@@ -70,7 +67,6 @@ public class LsstSsoAdapter implements SsoAdapter {
                     token = new Token(username);
                     token.setExpiresOn(0);
                     token.set(EMAIL, getString(ra, EMAIL_HEADER, null));
-                    token.set(NAME, getString(ra, NAME_HEADER, null));
                     token.set(UID, username);
                     token.set(ID_TOKEN, id_token);
 
@@ -90,12 +86,6 @@ public class LsstSsoAdapter implements SsoAdapter {
             //user.setLoginName(token.getId());
             user.setLoginName(token.get(UID));
             user.setEmail(token.get(EMAIL));
-            String name = token.get(NAME) == null ? "" : token.get(NAME);
-            String[] parts = name.split(" ");
-            String firstName = parts.length > 0 ? parts[0] : "";
-            String lastName = parts.length > 1 ? parts[1] : firstName;
-            user.setFirstName(firstName);
-            user.setLastName(lastName);
             return user;
         }
         return null;


### PR DESCRIPTION
We were passing the user's name in an HTTP header, but HTTP headers
only truly support ASCII (and, if not ASCII, use ISO 8859-1).  This
means we cannot represent many people's names.

Rather than use a more complicated encoding solution to pass the
name down, change SUIT to use the same behavior as squareone and only
show the user's username.  Do this by not setting the first or last
name attributes in UserInfo, which should trigger the Firefly
JavaScript layer to fall back to displaying only the username.