### PR TITLE
FIREFLY-1218: Allow onlinehelp base URL to be overridden as firefly options on the client

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -31,7 +31,7 @@ sso.server.url = "https://test.cilogon.org/"
 sso.login.url = "/login?rd=/portal/suit/"
 sso.logout.url = "/logout"
 sso.user.profile.url =
-help.base.url = "onlinehelp/"
+__$help.base.url = "onlinehelp/"
 
 sso.framework.adapter = "edu.caltech.ipac.lsst.security.LsstSsoAdapter"
 sso.auth.required = "false"


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1218
See for details. https://github.com/Caltech-IPAC/firefly/pull/1355