### PR TITLE
FIREFLY-1187: Add more TAP ObsCore options

### DIFF
--- a/src/suit/js/SUIT.js
+++ b/src/suit/js/SUIT.js
@@ -173,6 +173,7 @@ let options = {
         enableObsCoreDownload: true, // enable for other obscore
         [LSST_DP02_DC2]  : {
             enableObsCoreDownload: false, //disable for the portal
+            enableMetadataLoad: true, // loads metadata for columns to generate input field options
             filterDefinitions: [
                 {
                     name: 'LSSTCam',
@@ -196,13 +197,11 @@ let options = {
                 },
             },
             obsCoreInstrumentName: {
-                tooltip: 'LSSTCam, LSSTCam-imSim',
-                placeholder: 'e.g. LSSTCam-imSim',
+                tooltip: 'Name of instrument',
             },
             obsCoreSubType: {
                 tooltip: 'Specific type of image or other dataset',
-                placeholder: 'e.g. lsst.deepCoadd_calexp',
-                helptext: '"lsst." + Butler Repo Dataset type',
+                helptext: '"lsst." + Butler Repo Dataset type'
             },
         }
     },


### PR DESCRIPTION
Check https://github.com/Caltech-IPAC/firefly/pull/1552 for context and testing instructions


~NOTE: this is for testing purpose, and will need input from scientists for perfecting the options and tooltip/placeholder wordings~

- Don't need placeholder because options are fetched
- Add "enableMetadataLoad" to indicate it needs to be fetched for this service