### PR TITLE
FIREFLY-1747: LsstSsoAdapter entered an infinite loop when no auth token was present

### DIFF
--- a/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
+++ b/src/suit/java/edu/caltech/ipac/lsst/security/LsstSsoAdapter.java
@@ -53,6 +53,9 @@ public class LsstSsoAdapter implements SsoAdapter {
             try {
                 RequestAgent ra = ServerContext.getRequestOwner().getRequestAgent();
                 String id_token = getString(ra, TOKEN_HEADER, "");      // this is a 3-parts base64 encoded JWT token
+                if (isEmpty(id_token)) {
+                    return null;
+                }
                 String[] parts = id_token.split("\\.");
                 if (parts.length == 3) {
                     String jsonContent = new String(Base64.getDecoder().decode(parts[1]));
@@ -69,10 +72,7 @@ public class LsstSsoAdapter implements SsoAdapter {
                 } else {
                     String email = getString(ra, EMAIL_HEADER, null);
                     String username = getString(ra, USERNAME_HEADER, email);
-                    if (isEmpty(username)) {
-                        username = Try.it(() -> ServerContext.getRequestOwner().getUserKey())
-                                        .getOrElse(UUID.randomUUID().toString());       // all fail, use a random unique id
-                    }
+                    if (isEmpty(username))  username = UUID.randomUUID().toString();       // all fail, use a random unique id
                     token = new Token(username);
                     token.setExpiresOn(0);
                     token.set(EMAIL, email);


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1747

We observed this issue when an OPTIONS request was made without an auth token.

Test: 
Try this on a nightly build. 
```bash
curl -i -X OPTIONS -H 'Origin: https://rra.nb.data-int.lsst.cloud' -H 'Access-Control-Request-Method: GET' 'https://nightly.irsakudev.ipac.caltech.edu/suit/CmdSrv/sync?cmd=CmdJsonProperty'
```
Then, try this on the fixed version.
```bash
curl -i -X OPTIONS -H 'Origin: https://rra.nb.data-int.lsst.cloud' -H 'Access-Control-Request-Method: GET' 'https://firefly-1747-lsst-sso-loop.irsakudev.ipac.caltech.edu/suit/CmdSrv/sync?cmd=CmdJsonProperty'
```

This would also explain why the nightly build would not load.
https://nightly.irsakudev.ipac.caltech.edu/suit/