### PR TITLE
Set up Alertviewer on suit 

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -8,7 +8,7 @@ BuildNumber = 0
 // NB: the BuildType is overridden in the environment-specific settings below.
 BuildType = "Development"
 
-firefly.tag.name = "pre-2-2026.1"
+firefly.tag.name = "dev"
 
 mail.transport.protocol = "smtp"
 mail.smtp.host = "mail.ncsa.illinois.edu"

--- a/config/web-fragment.xml
+++ b/config/web-fragment.xml
@@ -9,4 +9,14 @@
         <url-pattern>/timeseries</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>alertviewer</servlet-name>
+        <jsp-file>/alertviewer.html</jsp-file>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>alertviewer</servlet-name>
+        <url-pattern>/alertviewer/*</url-pattern>
+    </servlet-mapping>
+
+
 </web-fragment>

--- a/src/suit/html/alertviewer.html
+++ b/src/suit/html/alertviewer.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="icon" type="image/x-icon" href="images/fftools-logo-16x16.png">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>Alert Viewer</title>
+
+    <script>
+        window.firefly = {
+            app: {
+                template: 'router',
+                page: 'alertviewer',
+            }
+        };
+    </script>
+    <script  type="text/javascript" src="firefly_loader.js"></script>
+</head>
+
+<body style="margin: 0">
+<!-- attached location for firefly app -->
+<div id='app' style="width:100vw;height: 100vh"/>
+</body>
+
+</html>
+
+

--- a/src/suit/js/SUIT.js
+++ b/src/suit/js/SUIT.js
@@ -25,6 +25,9 @@ import {
 } from './actions.jsx';
 import {getRubinDCECollectionAttributes, makeRubinDCERegistryRequest} from './RubinInventoryConfig';
 import {RubinLanding, RubinLandingAPI} from './RubinLanding.jsx';
+import {ROUTER} from 'firefly/templates/router/RouteHelper';
+import {alertviewer} from 'firefly/apps/alertviewer/alertviewer';
+import {AlertIdPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
 
 import APP_ICON from '../html/images/rubin-favicon-transparent-45px.png';
 import './suit.css';
@@ -36,6 +39,16 @@ const OTHER_CAT= 'Other archive searches';
 const RUBIN_DP1_IMAGES= RUBIN_DP1+'-images';
 const LSST_DP02_DC2_SIAV2_IMAGES= LSST_DP02_DC2+'-siaV2images';
 // const LSST_DP03_SSO_IMAGES=LSST_DP03_SSO+'-images';
+
+/**
+ * Pages are spa within a webapp.  In this case, a page can be alertviewer and a webapp is firefly(applications).
+ * @type {object}
+ * @prop {function} init  an init function to call after firefly completes bootstrap.
+ * @prop {object[]} menu  a list of menu for this page.
+ */
+const pages = {
+    alertviewer
+};
 
 /**
  * This entry point is customized for LSST suit.  Refer to FFEntryPoint.js for information on
@@ -69,6 +82,7 @@ let props = {
         {label: 'IRSA Catalogs', action: 'IrsaCatalog',  category:OTHER_CAT},
         {label: 'NED Objects', action: 'ClassicNedSearchCmd', primary: false, category:OTHER_CAT},
         {label: 'VO Cone Search', action: 'ClassicVOCatalogPanelCmd', primary: false, category: OTHER_CAT},
+        {label: 'Alert Viewer', action: 'AlertViewerSearch', primary: true, category: OTHER_CAT},
         {label: 'Upload', action: 'FileUploadDropDownCmd', primary:true}
     ],
     appTitle: 'Rubin Portal',
@@ -110,7 +124,7 @@ let props = {
                         layout= {{width: '100%'}} name='gaia-tap'/>,
         <TapSearchPanel lockService={true} lockedServiceName={LSST_DP03_SSO} groupKey={LSST_DP03_SSO}
                         layout= {{width: '100%'}} name={LSST_DP03_SSO}/>,
-
+        <AlertIdPanel name='AlertViewerSearch' loadInPlace={false} layout={{width: '100%'}}/>,
         <DLGeneratedDropDown {...{
             name:'RubinDataCollections',
             key:'RubinDataCollections',
@@ -329,13 +343,29 @@ let options = {
 };
 
 options = mergeObjectOnly(options, window.firefly?.options ?? {});
-firefly.bootstrap(props, options,
-    getFireflyViewerWebApiCommands(undefined,
-        [
-            {desc:LSST_DP02_DC2, name:LSST_DP02_DC2},
-            {desc:'DP1 Images', name:'rubin-obscore-images-dp1'},
-            {desc:'DP1 Catalogs', name:'rubin-catalogs-dp1'},
-            {desc:'DP0 Images', name:'rubin-obscore-images-dp0'},
-            {desc:'Gaia TAP at ESAC', name:'gaia-tap'},
-        ],
-    ));
+
+let apiCommands = getFireflyViewerWebApiCommands(
+    undefined,
+    [
+        {desc:LSST_DP02_DC2, name:LSST_DP02_DC2},
+        {desc:'DP1 Images', name:'rubin-obscore-images-dp1'},
+        {desc:'DP1 Catalogs', name:'rubin-catalogs-dp1'},
+        {desc:'DP0 Images', name:'rubin-obscore-images-dp0'},
+        {desc:'Gaia TAP at ESAC', name:'gaia-tap'},
+    ],
+);
+let initApp;
+
+const {template, page} = props;
+
+if (template === ROUTER) {
+    const pageDef = pages[page];
+    props = mergeObjectOnly(props, pageDef?.props);
+    options = mergeObjectOnly(options, pageDef?.options);
+    if (pageDef?.menu) props.menu = pageDef.menu;
+    apiCommands = pageDef?.webApiCommands;
+    initApp = pageDef?.init;
+}
+
+firefly.bootstrap(props, options, apiCommands).then(() => initApp?.());
+


### PR DESCRIPTION
**Firefly PR**: https://github.com/Caltech-IPAC/firefly/pull/1939

- Added the relevant code to make the `/alertviewer` endpoint work on suit

**Test**: 
Suit's Alertviewer: https://enable-alert-viewer.irsakubedev.ipac.caltech.edu/suit/alertviewer 
- Test that the endpoint works
- if you try and actual alert ID (like `170059278837088375`), you may expectedly get the missing/invalid token error. 
  - to test the UI, check out and run this branch locally 
  - I tested the URL API locally as well and it works for me, feel free to test that as well