### PR TITLE
Bug fix for web-fragments.xml (fixes alertviewer route)

### DIFF
--- a/src/suit/build.gradle
+++ b/src/suit/build.gradle
@@ -13,7 +13,11 @@ dependencies {
 }
 
 jar {
-  includes = ['edu/caltech/ipac/**/*']
+  includes = ['edu/caltech/ipac/**/*', 'web-fragment.xml']
+
+  from("$rootDir/config/web-fragment.xml") {
+    into 'META-INF'
+  }
 }
 
 onlinehelp {

--- a/src/suit/html/ts.html
+++ b/src/suit/html/ts.html
@@ -11,7 +11,7 @@
             app: {
                template: 'LightCurveViewer',     // set to use the light curve template
                 menu: [
-                    {label:'Upload', action:'LCUpload'}
+                    {label:'Upload', action:'LCUpload'},
                     {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
                 ],
             }


### PR DESCRIPTION
**Description**: 
  - Upon inspection, I found the built `suit.jar` did not have  suit's `web-fragment.xml`, which contains the servlet mapping for `alertviewer` 
  - The fix below attempts to put `web-fragment.xml` into `suit.jar` (firefly is a little different in that we put the `web.xml `file directly into the `WAR`). 
  - Open to a different/better solution, but I tested `suit` locally and this fixes the `alertviewer` issue. 

**Testing**:
- check out this branch, build it (you might need to remove the `suit` app from webapps in tomcat, and redeploy `suit` and restart tomcat), and try and access: http://localhost:8080/suit/alertviewer/
  - also do a couple of searches and ensure the results in UI look good (after our `react-split-pane` upgrade) 